### PR TITLE
fix for emtpy workspace

### DIFF
--- a/R/clear_document_and_reload.R
+++ b/R/clear_document_and_reload.R
@@ -29,7 +29,7 @@ clear_document_reload <- function() {
     silent = TRUE
   )
   
-  rm(list=ls(all.names = TRUE))
+  rm(list = ls(envir = .GlobalEnv), envir = .GlobalEnv)
   
   # Document and reload your package
   pkg <- getwd()


### PR DESCRIPTION
we've only emtied the environment within the function. To empty the global environment, we now specify .GlobalEnv